### PR TITLE
Allow building with base-4.10.0.0

### DIFF
--- a/old-locale.cabal
+++ b/old-locale.cabal
@@ -31,5 +31,5 @@ Library
     exposed-modules:
         System.Locale
 
-    build-depends: base >= 4.2 && < 4.11
+    build-depends: base >= 4.2 && < 5
     ghc-options: -Wall

--- a/old-locale.cabal
+++ b/old-locale.cabal
@@ -31,5 +31,5 @@ Library
     exposed-modules:
         System.Locale
 
-    build-depends: base >= 4.2 && < 4.9
+    build-depends: base >= 4.2 && < 4.11
     ghc-options: -Wall


### PR DESCRIPTION
Currently, the `old-locale` in this repo doesn't build with GHC 8.2 (or 8.0, for that matter!) due to restrictive upper version bounds on `base`.

(The version on Hackage does allow 8.0, but not 8.2., currently.)